### PR TITLE
Add a parenthetical at first use of 'third-party cookies' to clarify that we mean cross-site cookies.

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ var respecConfig = {
 
 <section id="abstract">
 
-This finding discusses the deprecation of third-party (cross-site) cookies, the reasons for restricting them, and the challenges in removing them from the web platform. We highlight some use cases that depend on third-party cookies and offer some examples of designed-for-purpose technologies that can replace them. Specification authors are expected to ensure they do not undermine the benefits of removing third-party cookies when proposing new web platform technologies.
+This finding discusses the deprecation of third-party (<abbr title="also known as">AKA</abbr> cross-site) cookies, the reasons for restricting them, and the challenges in removing them from the web platform. We highlight some use cases that depend on third-party cookies and offer some examples of designed-for-purpose technologies that can replace them. Specification authors are expected to ensure they do not undermine the benefits of removing third-party cookies when proposing new web platform technologies.
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ var respecConfig = {
 
 <section id="abstract">
 
-This finding discusses the deprecation of third-party cookies, the reasons for restricting them, and the challenges in removing them from the web platform. We highlight some use cases that depend on third-party cookies and offer some examples of designed-for-purpose technologies that can replace them. Specification authors are expected to ensure they do not undermine the benefits of removing third-party cookies when proposing new web platform technologies.
+This finding discusses the deprecation of third-party (cross-site) cookies, the reasons for restricting them, and the challenges in removing them from the web platform. We highlight some use cases that depend on third-party cookies and offer some examples of designed-for-purpose technologies that can replace them. Specification authors are expected to ensure they do not undermine the benefits of removing third-party cookies when proposing new web platform technologies.
 
 </section>
 


### PR DESCRIPTION
Partially addresses #14, in that the term "third-party cookies" is clarified at first use, but otherwise leaves the existing term in place because—despite its clear shortcomings—the term "third-party cookies" is probably the most widely-understood term.