### PR TITLE
Concentrate on use cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,12 +64,9 @@ We maintain that [security and privacy are essential](https://w3ctag.github.io/e
 
 ## Use cases previously met by third-party cookies
 
-Some features of the web that people have come to expect, and which greatly improve user experience, currently depend on third-party cookies, and continuing to support these use cases is important. It is better to approach this with replacement technologies that are designed-for-purpose and built to respect user privacy. Any proposal that acts as a general-purpose replacement for third-party cookies would need to be accompanied by evidence that it does not recreate the same issues.
+Some features of the web that people have come to expect, and which greatly improve user experience, currently depend on third-party cookies. Continuing to support these use cases is important. It is better to approach this with replacement technologies that are designed-for-purpose and built to respect user privacy. Any proposal that acts as a general-purpose replacement for third-party cookies would need to be accompanied by evidence that it does not recreate the same issues.
 
-Some recent good examples of the designed-for-purpose approach include:
-
-* [FedCM](https://github.com/w3ctag/design-reviews/issues/718). Third-party cookies have been used to support single sign-on. FedCM is a set of technologies built to support identity federation, without replicating all functionality of third-party cookies.
-* [CHIPS](https://github.com/w3ctag/design-reviews/issues/654). The goal of CHIPS is to allow state, without supporting correlation or tracking between web sites which don't know they are collaborating, for example, when embedding third-party services like customer service webchat.
+Some of the use cases that are important enough to justify the creation of purpose-specific solutions include federated identity, authorizing access to cross-site resources, and fraud mitigation. There is also active investigation of cross-site information in advertising, for both measurement and targeting purposes.
 
 In all cases, it is important to continually review how such proposals might interact with other emerging or proposed APIs. Be aware that a set of new technologies which carry minimal risk individually, could be used in combination for tracking or profiling of web users.
 


### PR DESCRIPTION
Not solutions.  We don't need to over-index on the solution part, particularly when we have just one solution that is really purpose-limited in the way we describe.

I like CHIPS, but it is not an API that does purpose limitation.